### PR TITLE
Remove stray paren

### DIFF
--- a/ws/templates/preferences/lottery/pairing.html
+++ b/ws/templates/preferences/lottery/pairing.html
@@ -22,7 +22,7 @@
 
 <p>
   The other participant must confirm that they are part of this pair.
-  Otherwise, no effort will be made to place you both on the same trip).
+  Otherwise, no effort will be made to place you both on the same trip.
 </p>
 
 <ul>


### PR DESCRIPTION
Just noticed a small typo. Thanks for all your hard work creating the MITOC trip signup. Definitely don't remember the process being this nice when I was in undergrad!