### PR TITLE
use an older version of django-localflavor 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django>=1.8.3,<1.9
 pytz
 celery==3.1.23
 django-allauth
-django-localflavor
+django-localflavor<2.0
 django-cors-headers
 django-debug-toolbar>=1.5
 django-pipeline


### PR DESCRIPTION
use an older version of django-localflavor that contains localflavor.us.models.PhoneNumberField