### PR TITLE
Render trip feedback newlines on profiles and the admin trips page.

### DIFF
--- a/ws/static/css/layout.css
+++ b/ws/static/css/layout.css
@@ -152,6 +152,10 @@ admin-trip-signups .signup-list .signup-summary .label {
   margin-right: 5px;
 }
 
+admin-trip-signups .signup-list-feedback {
+  white-space: pre-wrap;
+}
+
 /* Mimick the `img-responsive` class for images produced by the Markdown processor. */
 .trip-description img {
   display: block;

--- a/ws/static/template/editable-signup-list.html
+++ b/ws/static/template/editable-signup-list.html
@@ -40,7 +40,7 @@
         <div data-ng-if="signup.feedback.length && !hideFeedback">
           <label><i class="fas fa-comment"></i>&nbsp;Feedback</label>
           <ul class="list-unstyled" data-ng-repeat="feedback in signup.feedback">
-            <li>{{ feedback.comments }} - <small>{{ feedback.leader }} on <a data-ng-href="/trips/{{feedback.trip.id}}/" data-ng-bind="feedback.trip.name"></a></small></li>
+            <li class="signup-list-feedback">{{ feedback.comments }} - <small>{{ feedback.leader }} on <a data-ng-href="/trips/{{feedback.trip.id}}/" data-ng-bind="feedback.trip.name"></a></small></li>
           </ul>
         </div>
       </div>

--- a/ws/templates/for_templatetags/feedback_table.html
+++ b/ws/templates/for_templatetags/feedback_table.html
@@ -19,7 +19,7 @@
             <span class="label label-danger">Flaked!</span>
           {% endif %}
 
-          {{ feedback.comments }}
+          {{ feedback.comments|linebreaks }}
         </td>
         <td>
           <span class="nowrap">


### PR DESCRIPTION
I wanted to use newlines in my feedback to separate out trip conditions from participant feedback. I believe I found all places where feedback shows up – on a profile, the admin page for a trip, and in leader applications – but let me know if I missed anything.