### PR TITLE
Add link for reimbursements when creating trip

### DIFF
--- a/ws/templates/trips/__create_or_edit.html
+++ b/ws/templates/trips/__create_or_edit.html
@@ -121,8 +121,9 @@
   </div>
 
   <div class="alert alert-warning">
-    If you have an approved budget for this trip, please remember to register this event on Atlas
-    <a href="https://forms.gle/dNrbKyjnWavEHmK3A">here</a>, which is required for reimbursement.
+    If you have an approved budget for this trip, please remember to
+    <a href="https://forms.gle/dNrbKyjnWavEHmK3A">register this event on Atlas</a>,
+    which is required for reimbursement.
   </div>
   <button type="submit" class="btn btn-primary">Submit</button>
   <a role="button" class="btn btn-default"

--- a/ws/templates/trips/__create_or_edit.html
+++ b/ws/templates/trips/__create_or_edit.html
@@ -120,6 +120,10 @@
 
   </div>
 
+  <div class="alert alert-warning">
+    If you have an approved budget for this trip, please remember to register this event on Atlas
+    <a href="https://forms.gle/dNrbKyjnWavEHmK3A">here</a>, which is required for reimbursement.
+  </div>
   <button type="submit" class="btn btn-primary">Submit</button>
   <a role="button" class="btn btn-default"
     {% if form.instance.pk %}


### PR DESCRIPTION
Leaders keep on forgetting to register trips that need reimbursement on Atlas, which sometimes causes issues with reimbursement. Think it would be helpful to add this text (discussed / went over text with @pllilin) to the "create event" page, to remind leaders to fill out the required form.