### PR TITLE
Clarify discount headers

### DIFF
--- a/ws/templates/preferences/discounts.html
+++ b/ws/templates/preferences/discounts.html
@@ -6,7 +6,8 @@
 {% block content %}
 {{ block.super }}
 
-<h1>MITOC Discounts (Discontinued)</h1>
+<h1>MITOC Discounts</h1>
+<h2>Local Discounts (Discontinued)</h2>
 <p class="lead">
   Previously, MITOC allowed automatic sharing of information with local businesses.
 </p>
@@ -18,7 +19,7 @@
 
 {% if viewing_participant.is_student %}
 <hr>
-
+<h2>Other Discounts</h2>
 <div class="panel panel-default">
   <div class="panel-heading">
     <div class="row">


### PR DESCRIPTION
Hoping to add clarity to reduce volume of confused emails. 