### PR TITLE
Add notes about cross-registered students to membership page

### DIFF
--- a/ws/models.py
+++ b/ws/models.py
@@ -336,14 +336,14 @@ class Participant(models.Model):
             "Undergraduate student",
             [
                 (affiliations.MIT_UNDERGRAD.CODE, "MIT undergrad"),
-                (affiliations.NON_MIT_UNDERGRAD.CODE, "Non-MIT undergrad"),
+                (affiliations.NON_MIT_UNDERGRAD.CODE, "Non-MIT undergrad (includes cross-registered students)"),
             ],
         ),
         (
             "Graduate student",
             [
                 (affiliations.MIT_GRAD_STUDENT.CODE, "MIT grad student"),
-                (affiliations.NON_MIT_GRAD_STUDENT.CODE, "Non-MIT grad student"),
+                (affiliations.NON_MIT_GRAD_STUDENT.CODE, "Non-MIT grad student (includes cross-registered students)"),
             ],
         ),
         (

--- a/ws/templates/profile/edit.html
+++ b/ws/templates/profile/edit.html
@@ -24,7 +24,8 @@ Edit profile {% if participant %} - {{ participant.name }}{% endif %}
                    data-ng-cloak
                    data-ng-show="['MU', 'MG'].includes(affiliation)">
                 You must have a <a href="{% url 'account_email' %}">verified MIT email address</a>
-                in order to claim MIT student status.
+                in order to claim MIT student status. Cross-registered students are not eligible for 
+                MIT student status.
               </div>
 
               {# We allow people to claim MIT affiliation without an MIT email, but warn all the same #}

--- a/ws/templates/profile/membership.html
+++ b/ws/templates/profile/membership.html
@@ -99,6 +99,7 @@
         <div class="alert alert-warning" data-ng-cloak data-ng-show="membershipform.$valid && ['MU', 'MG'].includes(affiliation) && !email.endsWith('mit.edu')">
           <p>
             <strong>You must own an MIT email address</strong> in order to claim the MIT student rate.
+            Cross-registered students are not eligible for the MIT student rate.
           </p>
           <p>
             Prefer to use your personal email address for your membership?


### PR DESCRIPTION
Cross-registered students are not eligible for MIT student rates for MITOC memberships. 
This has always been the case, but these notes are meant to make it explicit on the 
membership page.

(I'm not sure if putting it in the drop-down is the best way to add this. Feel free to 
suggest other ways to add this.)