### PR TITLE
Render aspirational rating in summary application

### DIFF
--- a/ws/templates/for_templatetags/application_summary.html
+++ b/ws/templates/for_templatetags/application_summary.html
@@ -24,6 +24,8 @@
   </dd>
   <dt>Desired rating:</dt>
   <dd>{{ application.desired_rating }}</dd>
+  <dt>Aspirational rating:</dt>
+  <dd>{{ application.aspirational_rating }}</dd>
   {% if assigned_rating %}
     <dt>Assigned rating:</dt>
     <dd>{{ assigned_rating.rating }}</dd>


### PR DESCRIPTION
Render aspirational rating in summary application

This field is captured in applications, but not rendered in the application summary reviewed by the WSC