### PR TITLE
Use sort handle for signups on trip admin tab to make it scrollable on mobile

### DIFF
--- a/ws/static/css/layout.css
+++ b/ws/static/css/layout.css
@@ -114,9 +114,12 @@ label.required:after,
 }
 
 /* UI-sortable */
-.ui-sortable .list-group-item,
-.ui-sortable label {
+.ui-sortable .sort-handle {
   cursor: move;
+}
+
+.sort-handle {
+  padding-right: 5px;
 }
 
 admin-trip-signups button.btn-default {

--- a/ws/static/js/ws/forms.js
+++ b/ws/static/js/ws/forms.js
@@ -302,6 +302,7 @@ angular.module('ws.forms', ['ui.select', 'ngSanitize'])
         updateSignups(false);
       };
       scope.sortableOptions = {stop: updateKeepDeleted,
+                               handle: '.sort-handle',
                                connectWith: '.signup-list'};
       scope.$watch('maximumParticipants', updateKeepDeleted);
 

--- a/ws/static/template/editable-signup-list.html
+++ b/ws/static/template/editable-signup-list.html
@@ -2,6 +2,10 @@
   <div class="list-group-item" data-ng-repeat="signup in signups" data-ng-class="{'disabled': signup.deleted}">
     <div class="row">
       <div class="col-md-3">
+        <span class="sort-handle">
+          <i class="fas fa-grip-vertical mr-1"></i>
+        </span>
+	
         <i data-ng-if="signup.paired_with" class="fas fa-link"></i>
         <label data-ng-bind="signup.participant.name"></label>
         <car-badge data-car-status="signup.car_status"

--- a/ws/static/template/trip-rank.html
+++ b/ws/static/template/trip-rank.html
@@ -2,7 +2,7 @@
 
 <div data-ng-show="signups.length">
   <ul class="list-group" ui-sortable="sortableOptions" data-ng-model="activeSignups">
-    <li class="list-group-item clearfix" data-ng-repeat="signup in activeSignups">
+    <li class="list-group-item clearfix sort-handle" data-ng-repeat="signup in activeSignups">
       <span data-ng-bind="'#' + ($index + 1)"></span>
       <label data-ng-bind="signup.trip__name"></label>
       <button type="button" class="btn btn-sm btn-danger pull-right" data-ng-click="deleteSignup(signup, $index)">Delete</button>


### PR DESCRIPTION
Re-addresses #105.

On mobile, the active area for starting drag-and-drop for signups on the admin spans almost the entire width of the screen, making it very difficult to scroll. By reducing the active area for starting a drag-and-drop operation to a smaller icon, it makes it much easier to scroll the page on mobile, while reducing the chance of accidentally reordering signups.

Here's a recording of what it looks like to use the page in firefox dev tools simulating a mobile device. The cursor icon bugginess is an artifact of simulating touch inputs with a mouse.

![Recording 2026-01-24 at 17 40 37](https://github.com/user-attachments/assets/57f9d61b-b534-48dd-98c7-fe69b262ed10)

On my actual phone, the scrolling experience is much more comfortable and the active area for beginning a drag is big enough to hit when I do mean to hit it.

On desktop, the cursor only switches to the grab icon when you are hovering over the drag handle.

<img width="1471" height="1178" alt="image" src="https://github.com/user-attachments/assets/a61835ae-43a5-4e73-a71a-55255670d699" />

I've left the other usage of ui-sortable in the lottery ranking selection alone. There are some minor CSS changes, but the cursor still behaves properly there.

<img width="733" height="234" alt="image" src="https://github.com/user-attachments/assets/9fe9bef0-567e-42a1-b220-8499f1afb38f" />


