### PR TITLE
Show everyone information about the Ikon Pass program.

### DIFF
--- a/ws/templates/preferences/discounts.html
+++ b/ws/templates/preferences/discounts.html
@@ -16,8 +16,6 @@
   discounts (at their own discretion) to MITOCers. Inquire directly at those
   businesses; MITOC does not manage these programs in any way.
 </p>
-
-{% if viewing_participant.is_student %}
 <hr>
 <h2>Other Discounts</h2>
 <div class="panel panel-default">
@@ -68,5 +66,4 @@
 
   </div>
 </div>
-{% endif %}
 {% endblock content %}


### PR DESCRIPTION
I've been getting lots of emails from students who don't realize that you have to be logged in to see the Ikon Pass discount information. There's no harm in showing everyone the information, so this PR removes conditional rendering for the discount information.